### PR TITLE
Colocate shards into tablet to batch transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ either = "1.9.0"
 atomic = "0.6.0"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 futures = "0.3.28"
+thiserror = "1.0.48"
 
 [dev-dependencies]
 assertor = "0.0.2"

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -18,9 +18,15 @@ mod meta;
 mod node;
 
 pub use self::env::ClusterEnv;
-pub use self::meta::{ClusterDeploymentMonitor, ClusterDeploymentWatcher, ClusterMetaHandle, EtcdClusterMetaDaemon};
+pub use self::meta::{
+    ClusterDeploymentMonitor,
+    ClusterDeploymentWatcher,
+    ClusterDescriptorWatcher,
+    ClusterMetaHandle,
+    EtcdClusterMetaDaemon,
+};
 pub use self::node::{EtcdNodeRegistry, NodeId, NodeLease, NodeRegistry, NodeStatistics, NodeStatisticsWatcher};
-pub use crate::protos::ClusterMeta;
+pub use crate::protos::ClusterDescriptor;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Write;
+
 use anyhow::{bail, Result};
 
+use crate::protos::{KeyRange, TabletId};
+
+pub const TABLET_DESCRIPTOR_KEY_PREFIX: &[u8] = &[b'T', b'D'];
+pub const TABLET_DEPLOYMENT_KEY_PREFIX: &[u8] = &[b'T', b'T'];
 pub const ROOT_KEY_PREFIX: &[u8] = &[b'a', b'1'];
 pub const RANGE_KEY_PREFIX: &[u8] = &[b'a', b'2'];
 pub const DATA_KEY_PREFIX: &[u8] = &[b'd'];
@@ -60,6 +66,36 @@ pub fn root_key(key: &[u8]) -> Vec<u8> {
     rooted_key.extend(ROOT_KEY_PREFIX.iter());
     rooted_key.extend(key.iter());
     rooted_key
+}
+
+pub fn descriptor_key(id: TabletId) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(TABLET_DESCRIPTOR_KEY_PREFIX);
+    write!(&mut buf, "{}", id).unwrap();
+    buf
+}
+
+pub fn deployment_key(id: TabletId) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(TABLET_DEPLOYMENT_KEY_PREFIX);
+    write!(&mut buf, "{}", id).unwrap();
+    buf
+}
+
+pub fn descriptor_range() -> KeyRange {
+    let start = TABLET_DESCRIPTOR_KEY_PREFIX.to_owned();
+    let mut end = Vec::with_capacity(TABLET_DESCRIPTOR_KEY_PREFIX.len() + 1);
+    end.extend_from_slice(TABLET_DESCRIPTOR_KEY_PREFIX);
+    end.push(b'z');
+    KeyRange { start, end }
+}
+
+pub fn deployment_range() -> KeyRange {
+    let start = TABLET_DEPLOYMENT_KEY_PREFIX.to_owned();
+    let mut end = Vec::with_capacity(TABLET_DEPLOYMENT_KEY_PREFIX.len() + 1);
+    end.extend_from_slice(TABLET_DEPLOYMENT_KEY_PREFIX);
+    end.push(b'z');
+    KeyRange { start, end }
 }
 
 pub fn range_key(key: &[u8]) -> Vec<u8> {

--- a/src/protos/build/src/main.rs
+++ b/src/protos/build/src/main.rs
@@ -52,15 +52,14 @@ fn main() {
         .require_field("TimestampedValue.value")
         .require_field("TimestampedValue.timestamp")
         .require_field("PutResponse.write_ts")
+        .require_field("LocateResponse.shard")
         .require_field("LocateResponse.deployment")
-        .require_field("TabletDepot.range")
+        .require_field("ClusterDescriptor.timestamp")
+        .require_field("ShardDescriptor.range")
+        .require_field("ShardDescription.range")
         .require_field("TabletManifest.tablet")
         .require_field("TabletManifest.watermark")
-        .require_field("TabletDescriptor.range")
-        .require_field("TabletDeployment.tablet")
-        .require_field("TabletListRequest.range")
-        .require_field("TabletDeployRequest.deployment")
-        .require_field("TabletDescription.depot");
+        .require_field("TabletDeployRequest.deployment");
 
     tonic_build::configure().out_dir(&outdir).compile_with_config(config, &protos, &[protos_dir]).unwrap();
 

--- a/src/protos/protos/seamdb.proto
+++ b/src/protos/protos/seamdb.proto
@@ -22,47 +22,75 @@ message MessageId {
     uint64 sequence = 2;
 }
 
-message TabletRange {
+message KeyRange {
     bytes start = 1;
     bytes end = 2;
 }
 
-message TabletDepotSegment {
+message ShardSegment {
     string file = 1;
     string log = 2;
-    TabletRange range = 3;
+    KeyRange range = 3;
 }
 
-message TabletDepot {
-    repeated TabletDepotSegment segments = 1;
+message ShardDepot {
+    repeated ShardSegment segments = 1;
     string file = 2;
     // kafka://kafka-cluster-address/topic-name?start=1
     string log = 3;
-    TabletRange range = 4;
+    KeyRange range = 4;
 }
 
-enum TabletMergeBounds {
+enum ShardMergeBounds {
     All = 0;
     Left = 1;
     Right = 2;
     None = 3;
 }
 
-message TabletDescriptor {
+// range/range1_end_key ==> ShardDescriptor
+message ShardDescriptor {
     uint64 id = 1;
     // Increment on each split/merge.
+    //
+    // XXX: What if a query arrive after range split ?
     uint64 generation = 2;
-    TabletRange range = 3;
-    string log = 4;
+    KeyRange range = 3;
+    uint64 tablet_id = 4;
+}
+
+message ShardDescription {
+    uint64 id = 1;
+    uint64 generation = 2;
+    KeyRange range = 3;
+    repeated ShardSegment segments = 4;
 
     // Default to All.
-    TabletMergeBounds merge_bounds = 5;
+    ShardMergeBounds merge_bounds = 5;
+}
+
+// system/tablets/deployments/id1 ==> deployment1
+message TabletDeployment {
+    uint64 id = 1;
+    // Increment on leader change.
+    uint64 epoch = 2;
+    // Increment on not-leader change and reset on leader change.
+    uint64 generation = 3;
+    repeated string servers = 4;
+}
+
+message TabletDescriptor {
+    uint64 id = 1;
+    uint64 generation = 2;
+    string manifest_log = 4;
 }
 
 message TabletDescription {
     uint64 id = 1;
     uint64 generation = 2;
-    TabletDepot depot = 4;
+    // sort by range
+    repeated ShardDescription shards = 3;
+    string data_log = 4;
 }
 
 message TabletManifest {
@@ -181,7 +209,7 @@ message Transaction {
     TxnStatus status = 7;
 
     // Write set to resolve in txn commitment.
-    repeated Span write_set = 8;
+    repeated WriteSpan write_set = 8;
 
     // Milliseconds that transaction read will fence write.
     uint32 fence_duration = 10;
@@ -215,7 +243,7 @@ message TxnRecord {
 
     TxnStatus status = 7;
 
-    repeated Span write_set = 8;
+    repeated WriteSpan write_set = 8;
 
     Timestamp heartbeat_ts = 9;
 }
@@ -265,15 +293,6 @@ message TxnIntent {
     repeated Intent history = 4;
 }
 
-message TabletDeployment {
-    TabletDescriptor tablet = 1;
-    // Increment on leader change.
-    uint64 epoch = 2;
-    // Increment on not-leader change and reset on leader change.
-    uint64 generation = 3;
-    repeated string servers = 4;
-}
-
 message TabletDeployRequest {
     TabletDeployment deployment = 1;
 }
@@ -288,22 +307,17 @@ message TabletWatermark {
     Timestamp leader_expiration = 4;
 }
 
-message TabletListRequest {
-    TabletRange range = 1;
-}
-
 message TabletListResponse {
     repeated TabletDeployment deployments = 1;
 }
 
-message ClusterMeta {
+// cluster/descriptor
+message ClusterDescriptor {
     string name = 1;
 
-    uint64 epoch = 2;
-    uint64 generation = 3;
-    repeated string servers = 4;
-
-    string log = 5;
+    uint64 generation = 2;
+    Timestamp timestamp = 3;
+    string manifest_log = 5;
 
     repeated string bootstrap_logs = 6;
     repeated string obsoleted_logs = 7;
@@ -327,7 +341,7 @@ message DataResponse {
     }
 }
 
-message Span {
+message WriteSpan {
     bytes key = 1;
     bytes end_key = 2;
 }
@@ -349,6 +363,7 @@ message BatchRequest {
 
     Temporal temporal = 3;
 
+    repeated uint64 shards = 4;
     repeated DataRequest requests = 5;
 }
 
@@ -367,7 +382,8 @@ message LocateRequest {
 }
 
 message LocateResponse {
-    TabletDeployment deployment = 1;
+    ShardDescriptor shard = 1;
+    TabletDeployment deployment = 2;
 }
 
 message GetRequest {
@@ -414,20 +430,20 @@ message IncrementResponse {
     int64 value = 1;
 }
 
-message HeartbeatRequest {
+message TabletHeartbeatRequest {
     uint64 tablet_id = 1;
 }
 
-message HeartbeatResponse {}
+message TabletHeartbeatResponse {
+    TabletDeployment deployment = 1;
+}
 
 service TabletService {
-    rpc ListTablets(TabletListRequest) returns (TabletListResponse);
-
     rpc DeployTablet(TabletDeployRequest) returns (TabletDeployResponse);
+
+    rpc HeartbeatTablet(TabletHeartbeatRequest) returns (TabletHeartbeatResponse);
 
     rpc Batch(BatchRequest) returns (BatchResponse);
 
     rpc Locate(LocateRequest) returns (LocateResponse);
-
-    rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
 }

--- a/src/tablet/memory.rs
+++ b/src/tablet/memory.rs
@@ -13,140 +13,29 @@
 // limitations under the License.
 
 use std::collections::btree_map::{BTreeMap, Entry};
-use std::collections::VecDeque;
-use std::convert::TryFrom;
 use std::ops::RangeFrom;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::Result;
 
-use super::types::{
-    BatchResult,
-    MessageId,
-    ReplicationTracker,
-    ReplicationWatcher,
-    TabletStore,
-    TabletWatermark,
-    Temporal,
-    Timestamp,
-    TimestampedValue,
-    Value,
-};
-use crate::protos::{
-    self,
-    DataMessage,
-    DataOperation,
-    DataRequest,
-    DataResponse,
-    FindResponse,
-    GetResponse,
-    IncrementResponse,
-    PutResponse,
-};
-
-enum Writes {
-    Write(protos::Write),
-    Batch(Vec<protos::Write>),
-}
-
-impl From<Option<DataOperation>> for Writes {
-    fn from(operation: Option<DataOperation>) -> Self {
-        match operation {
-            None => Writes::Batch(Default::default()),
-            Some(DataOperation::Write(write)) => Writes::Write(write),
-            Some(DataOperation::Batch(mut batch)) => {
-                batch.writes.reverse();
-                Writes::Batch(batch.writes)
-            },
-        }
-    }
-}
-
-impl ExactSizeIterator for Writes {}
-
-impl Iterator for Writes {
-    type Item = protos::Write;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match std::mem::replace(self, Writes::Batch(Default::default())) {
-            Writes::Write(write) => Some(write),
-            Writes::Batch(mut batch) => {
-                let write = batch.pop();
-                if !batch.is_empty() {
-                    unsafe { std::ptr::write(self, Writes::Batch(batch)) };
-                }
-                write
-            },
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            Writes::Write(_) => (1, Some(1)),
-            Writes::Batch(writes) => (writes.len(), Some(writes.len())),
-        }
-    }
-}
+use super::store::DataStore;
+use super::types::{Temporal, Timestamp, TimestampedValue, Value};
 
 #[derive(Default)]
-pub struct MemoryTabletStore {
-    watermark: TabletWatermark,
-    watermarks: VecDeque<TabletWatermark>,
+pub struct MemoryStore {
     table: MemoryTable<Timestamp, Value>,
 }
 
-impl MemoryTabletStore {
-    fn step(&mut self) {
-        self.watermark.cursor.sequence += 1;
-        self.check_cursor();
-    }
-
-    fn update_cursor(&mut self, cursor: MessageId) {
-        if cursor > self.watermark.cursor {
-            self.watermark.cursor = cursor;
-            self.check_cursor();
-        }
-    }
-
-    fn check_cursor(&mut self) {
-        let Some(next_watermark) = self.watermarks.front() else {
-            return;
-        };
-        if next_watermark.cursor > self.watermark.cursor {
-            return;
-        }
-        let watermark = self.watermarks.pop_front().unwrap();
-        if watermark.timing() > self.watermark.timing() {
-            self.watermark.closed_timestamp = watermark.closed_timestamp;
-            self.watermark.leader_expiration = watermark.leader_expiration;
-        }
-    }
-}
-
-impl TabletStore for MemoryTabletStore {
-    fn cursor(&self) -> MessageId {
-        self.watermark.cursor
-    }
-
-    fn watermark(&self) -> &TabletWatermark {
-        &self.watermark
-    }
-
-    fn update_watermark(&mut self, watermark: TabletWatermark) {
-        if watermark.cursor <= self.watermark.cursor {
-            if watermark.timing() > self.watermark.timing() {
-                self.watermark.closed_timestamp = watermark.closed_timestamp;
-                self.watermark.leader_expiration = watermark.leader_expiration;
-            }
-        } else if watermark.timing() > self.watermark.timing() {
-            self.watermarks.push_back(watermark);
-        }
-    }
-
+impl DataStore for MemoryStore {
     fn get(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
         let Some((ts, value)) = self.table.get(key, temporal.timestamp()) else {
             return Ok(TimestampedValue::default());
         };
         Ok(TimestampedValue::new(ts, value).adjust_timestamp())
+    }
+
+    fn put(&mut self, key: Vec<u8>, ts: Timestamp, value: Value) -> Result<()> {
+        self.table.put(key, ts, value);
+        Ok(())
     }
 
     fn find(&self, key: &[u8], temporal: &Temporal) -> Result<(Vec<u8>, TimestampedValue)> {
@@ -155,73 +44,19 @@ impl TabletStore for MemoryTabletStore {
         };
         Ok((key.to_owned(), TimestampedValue::new(ts, value).adjust_timestamp()))
     }
-
-    fn apply(&mut self, mut message: DataMessage) -> Result<()> {
-        let cursor = MessageId::new(message.epoch, message.sequence);
-        self.update_cursor(cursor);
-        if let (Some(closed_timestamp), Some(leader_expiration)) =
-            (message.closed_timestamp.take(), message.leader_expiration.take())
-        {
-            let watermark = TabletWatermark { cursor, closed_timestamp, leader_expiration };
-            self.update_watermark(watermark);
-        }
-        let Some(temporal) = message.temporal.take() else {
-            return Ok(());
-        };
-        let temporal = Temporal::try_from(temporal)?;
-        let ts = temporal.timestamp();
-        let writes = Writes::from(message.operation.take());
-        for write in writes {
-            self.table.put(write.key, ts, Value::from(write.value));
-        }
-        Ok(())
-    }
-
-    fn batch(&mut self, temporal: &mut Temporal, requests: Vec<DataRequest>) -> Result<BatchResult> {
-        let mut tablet = VirtualTablet::new(self);
-        let mut blocker = ReplicationWatcher::default();
-        let mut responses = Vec::with_capacity(requests.len());
-        for request in requests {
-            match request {
-                DataRequest::Get(get) => {
-                    let value = tablet.get(temporal, &get.key)?;
-                    blocker.watch(&value.value);
-                    let response = GetResponse { value: value.into() };
-                    responses.push(DataResponse::Get(response));
-                },
-                DataRequest::Find(find) => {
-                    let (key, value) = tablet.find(temporal, &find.key)?;
-                    blocker.watch(&value.value);
-                    let response = FindResponse { key, value: value.into() };
-                    responses.push(DataResponse::Find(response));
-                },
-                DataRequest::Put(put) => {
-                    let ts = tablet.put(temporal, &put.key, put.value, put.expect_ts)?;
-                    let response = PutResponse { write_ts: ts };
-                    responses.push(DataResponse::Put(response));
-                },
-                DataRequest::Increment(increment) => {
-                    let incremented = tablet.increment(temporal, &increment.key, increment.increment)?;
-                    let response = IncrementResponse { value: incremented };
-                    responses.push(DataResponse::Increment(response));
-                },
-            }
-        }
-        let (writes, replication) = tablet.commit();
-        if !writes.is_empty() {
-            self.step();
-        }
-        Ok(BatchResult { ts: temporal.timestamp(), blocker, responses, writes, replication })
-    }
 }
 
 #[derive(Default)]
-struct MemoryTable<S, V> {
+pub struct MemoryTable<S, V> {
     map: BTreeMap<Vec<u8>, Vec<(S, V)>>,
 }
 
 impl<S: Copy + Ord + std::fmt::Debug, V: Clone + std::fmt::Debug> MemoryTable<S, V> {
-    fn get(&self, key: &[u8], seq: S) -> Option<(S, V)> {
+    pub fn take(&mut self) -> BTreeMap<Vec<u8>, Vec<(S, V)>> {
+        std::mem::take(&mut self.map)
+    }
+
+    pub fn get(&self, key: &[u8], seq: S) -> Option<(S, V)> {
         let Some(values) = self.map.get(key) else {
             return None;
         };
@@ -233,7 +68,7 @@ impl<S: Copy + Ord + std::fmt::Debug, V: Clone + std::fmt::Debug> MemoryTable<S,
         None
     }
 
-    fn find(&self, key: &[u8], seq: S) -> Option<(Vec<u8>, S, V)> {
+    pub fn find(&self, key: &[u8], seq: S) -> Option<(Vec<u8>, S, V)> {
         let range = self.map.range(RangeFrom { start: key.to_owned() });
         for (key, values) in range {
             for (s, v) in values.iter().rev() {
@@ -245,90 +80,12 @@ impl<S: Copy + Ord + std::fmt::Debug, V: Clone + std::fmt::Debug> MemoryTable<S,
         None
     }
 
-    fn put(&mut self, key: Vec<u8>, seq: S, value: V) {
+    pub fn put(&mut self, key: Vec<u8>, seq: S, value: V) {
         match self.map.entry(key) {
             Entry::Vacant(vacent) => {
                 vacent.insert(vec![(seq, value)]);
             },
             Entry::Occupied(occupied) => occupied.into_mut().push((seq, value)),
         }
-    }
-}
-
-struct VirtualTablet<'a> {
-    tablet: &'a mut MemoryTabletStore,
-    provision: MemoryTable<Timestamp, Value>,
-
-    writes: Vec<protos::Write>,
-    replication: ReplicationTracker,
-}
-
-impl<'a> VirtualTablet<'a> {
-    pub fn new(tablet: &'a mut MemoryTabletStore) -> Self {
-        Self { tablet, provision: Default::default(), writes: Default::default(), replication: Default::default() }
-    }
-
-    pub fn get(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
-        if let Some((ts, value)) = self.provision.get(key, temporal.timestamp()) {
-            return Ok(TimestampedValue::new(ts, value).adjust_timestamp());
-        };
-        self.tablet.get(temporal, key)
-    }
-
-    pub fn find(&self, temporal: &Temporal, key: &[u8]) -> Result<(Vec<u8>, TimestampedValue)> {
-        if let Some((key, ts, value)) = self.provision.find(key, temporal.timestamp()) {
-            return Ok((key.to_owned(), TimestampedValue::new(ts, value).adjust_timestamp()));
-        }
-        self.tablet.find(key, temporal)
-    }
-
-    fn check_write(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
-        let value = self.get(temporal, key)?;
-        // FIXME: allow equal timestamp for now to gain write-your-write.
-        if temporal.timestamp() < value.timestamp {
-            return Err(anyhow!("write@{} encounters newer timestamp {}", temporal.timestamp(), value.timestamp));
-        }
-        Ok(value.adjust_timestamp())
-    }
-
-    fn add_write(&mut self, ts: Timestamp, key: Vec<u8>, value: Option<protos::Value>) {
-        let write = protos::Write { key: key.clone(), value: value.clone(), sequence: 0 };
-        self.writes.push(write);
-        let (value, replication) = Value::new(value);
-        self.provision.put(key, ts, value);
-        self.replication.batch(replication);
-    }
-
-    fn put(
-        &mut self,
-        temporal: &Temporal,
-        key: &[u8],
-        value: Option<protos::Value>,
-        expect_ts: Option<Timestamp>,
-    ) -> Result<Timestamp> {
-        let existing_value = self.check_write(temporal, key)?;
-        if let Some(expect_ts) = expect_ts.filter(|ts| *ts != existing_value.timestamp) {
-            bail!("mismatch timestamp check: existing ts {}, expect ts {:}", existing_value.timestamp, expect_ts)
-        }
-        self.add_write(temporal.timestamp(), key.to_owned(), value);
-        Ok(temporal.timestamp())
-    }
-
-    fn increment(&mut self, temporal: &Temporal, key: &[u8], increment: i64) -> Result<i64> {
-        let value = self.check_write(temporal, key)?;
-        let i = value.value.read_int(key, "increment")?;
-        let incremented = i + increment;
-        let value = protos::Value::Int(incremented);
-        self.add_write(temporal.timestamp(), key.to_owned(), Some(value));
-        Ok(incremented)
-    }
-
-    pub fn commit(self) -> (Vec<protos::Write>, ReplicationTracker) {
-        for (key, values) in self.provision.map.into_iter() {
-            for (ts, value) in values.into_iter() {
-                self.tablet.table.put(key.clone(), ts, value);
-            }
-        }
-        (self.writes, self.replication)
     }
 }

--- a/src/tablet/mod.rs
+++ b/src/tablet/mod.rs
@@ -18,6 +18,7 @@ mod loader;
 mod memory;
 mod node;
 mod service;
+mod store;
 mod types;
 
 pub use self::client::TabletClient;
@@ -34,11 +35,11 @@ pub use self::loader::{
 };
 pub use self::node::TabletNode;
 pub use self::service::TabletServiceImpl;
-pub use self::types::{BatchResult, ReplicationStage, Temporal, Timestamp, TimestampedValue};
+pub use self::store::BatchResult;
+pub use self::types::{ReplicationStage, Temporal, Timestamp, TimestampedValue};
 pub use crate::protos::{
     MessageId,
     TabletDeployment,
-    TabletDepot,
     TabletDescription,
     TabletDescriptor,
     TabletManifest,

--- a/src/tablet/store.rs
+++ b/src/tablet/store.rs
@@ -1,0 +1,408 @@
+// Copyright 2023 The SeamDB Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+use anyhow::{anyhow, bail, Result};
+
+use super::types::{ReplicationTracker, ReplicationWatcher, TimestampedValue, Value};
+use crate::protos::{
+    self,
+    DataOperation,
+    DataRequest,
+    DataResponse,
+    FindResponse,
+    GetResponse,
+    IncrementResponse,
+    KeyRange,
+    MessageId,
+    PutResponse,
+    ShardDescription,
+    ShardId,
+    TabletId,
+    TabletWatermark,
+    Timestamp,
+};
+use crate::tablet::memory::{MemoryStore, MemoryTable};
+use crate::tablet::types::Temporal;
+
+enum Writes {
+    Write(protos::Write),
+    Batch(Vec<protos::Write>),
+}
+
+impl From<Option<DataOperation>> for Writes {
+    fn from(operation: Option<DataOperation>) -> Self {
+        match operation {
+            None => Writes::Batch(Default::default()),
+            Some(DataOperation::Write(write)) => Writes::Write(write),
+            Some(DataOperation::Batch(mut batch)) => {
+                batch.writes.reverse();
+                Writes::Batch(batch.writes)
+            },
+        }
+    }
+}
+
+impl ExactSizeIterator for Writes {}
+
+impl Iterator for Writes {
+    type Item = protos::Write;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match std::mem::replace(self, Writes::Batch(Default::default())) {
+            Writes::Write(write) => Some(write),
+            Writes::Batch(mut batch) => {
+                let write = batch.pop();
+                if !batch.is_empty() {
+                    unsafe { std::ptr::write(self, Writes::Batch(batch)) };
+                }
+                write
+            },
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Writes::Write(_) => (1, Some(1)),
+            Writes::Batch(writes) => (writes.len(), Some(writes.len())),
+        }
+    }
+}
+
+pub struct BatchResult {
+    pub ts: Timestamp,
+
+    pub blocker: ReplicationWatcher,
+    pub responses: Vec<protos::DataResponse>,
+
+    pub writes: Vec<protos::Write>,
+    pub replication: ReplicationTracker,
+}
+
+impl BatchResult {
+    pub fn take_writes(&mut self) -> Vec<protos::Write> {
+        std::mem::take(&mut self.writes)
+    }
+}
+
+#[derive(Default)]
+struct BatchContext {
+    writes: Vec<protos::Write>,
+    replication: ReplicationTracker,
+}
+
+struct ShardStore {
+    id: ShardId,
+    range: KeyRange,
+    store: Box<dyn DataStore>,
+    provision: MemoryTable<Timestamp, Value>,
+}
+
+impl ShardStore {
+    pub fn new(id: ShardId, range: KeyRange) -> Self {
+        Self { id, range, store: Box::<MemoryStore>::default(), provision: MemoryTable::default() }
+    }
+
+    pub fn get(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
+        if let Some((ts, value)) = self.provision.get(key, temporal.timestamp()) {
+            return Ok(TimestampedValue::new(ts, value).adjust_timestamp());
+        };
+        self.store.get(temporal, key)
+    }
+
+    pub fn find(&self, temporal: &Temporal, key: &[u8]) -> Result<(Vec<u8>, TimestampedValue)> {
+        if let Some((key, ts, value)) = self.provision.find(key, temporal.timestamp()) {
+            return Ok((key.to_owned(), TimestampedValue::new(ts, value).adjust_timestamp()));
+        }
+        self.store.find(key, temporal)
+    }
+
+    fn check_write(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
+        let value = self.get(temporal, key)?;
+        // FIXME: allow equal timestamp for now to gain write-your-write.
+        if temporal.timestamp() < value.timestamp {
+            return Err(anyhow!("write@{} encounters newer timestamp {}", temporal.timestamp(), value.timestamp));
+        }
+        Ok(value.adjust_timestamp())
+    }
+
+    fn add_write(&mut self, context: &mut BatchContext, ts: Timestamp, key: Vec<u8>, value: Option<protos::Value>) {
+        let write = protos::Write { key: key.clone(), value: value.clone(), sequence: 0 };
+        context.writes.push(write);
+        let (value, replication) = Value::new(value);
+        self.provision.put(key, ts, value);
+        context.replication.batch(replication);
+    }
+
+    fn put(
+        &mut self,
+        context: &mut BatchContext,
+        temporal: &Temporal,
+        key: &[u8],
+        value: Option<protos::Value>,
+        expect_ts: Option<Timestamp>,
+    ) -> Result<Timestamp> {
+        let existing_value = self.check_write(temporal, key)?;
+        if let Some(expect_ts) = expect_ts.filter(|ts| *ts != existing_value.timestamp) {
+            bail!("mismatch timestamp check: existing ts {}, expect ts {:}", existing_value.timestamp, expect_ts)
+        }
+        self.add_write(context, temporal.timestamp(), key.to_owned(), value);
+        Ok(temporal.timestamp())
+    }
+
+    fn increment(
+        &mut self,
+        context: &mut BatchContext,
+        temporal: &Temporal,
+        key: &[u8],
+        increment: i64,
+    ) -> Result<i64> {
+        let value = self.check_write(temporal, key)?;
+        let i = value.value.read_int(key, "increment")?;
+        let incremented = i + increment;
+        let value = protos::Value::Int(incremented);
+        self.add_write(context, temporal.timestamp(), key.to_owned(), Some(value));
+        Ok(incremented)
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        for (key, values) in self.provision.take().into_iter() {
+            for (ts, value) in values.into_iter() {
+                self.store.put(key.clone(), ts, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn abort(&mut self) {
+        self.provision.take();
+    }
+}
+
+pub struct TabletStore {
+    id: TabletId,
+    stores: Vec<ShardStore>,
+    watermark: TabletWatermark,
+    watermarks: VecDeque<TabletWatermark>,
+}
+
+impl TabletStore {
+    pub fn new(id: TabletId, shards: &[ShardDescription]) -> Self {
+        let stores = shards.iter().map(|s| ShardStore::new(s.id.into(), s.range.clone())).collect();
+        Self { id, stores, watermark: Default::default(), watermarks: Default::default() }
+    }
+
+    fn step(&mut self) {
+        self.watermark.cursor.sequence += 1;
+        self.check_cursor();
+    }
+
+    fn update_cursor(&mut self, cursor: MessageId) {
+        if cursor > self.watermark.cursor {
+            self.watermark.cursor = cursor;
+            self.check_cursor();
+        }
+    }
+
+    fn check_cursor(&mut self) {
+        let Some(next_watermark) = self.watermarks.front() else {
+            return;
+        };
+        if next_watermark.cursor > self.watermark.cursor {
+            return;
+        }
+        let watermark = self.watermarks.pop_front().unwrap();
+        if watermark.timing() > self.watermark.timing() {
+            self.watermark.closed_timestamp = watermark.closed_timestamp;
+            self.watermark.leader_expiration = watermark.leader_expiration;
+        }
+    }
+
+    fn get_shard(&self, id: ShardId) -> Result<&ShardStore> {
+        for store in self.stores.iter() {
+            if store.id == id {
+                return Ok(store);
+            }
+        }
+        bail!("shard {} not found in tablet {}", id, self.id)
+    }
+
+    fn get_shard_mut(&mut self, id: ShardId) -> Result<&mut ShardStore> {
+        for store in self.stores.iter_mut() {
+            if store.id == id {
+                return Ok(store);
+            }
+        }
+        bail!("shard {} not found in tablet {}", id, self.id)
+    }
+
+    fn find_shard_mut(&mut self, key: &[u8]) -> Result<&mut ShardStore> {
+        for store in self.stores.iter_mut() {
+            if store.range.contains(key) {
+                return Ok(store);
+            }
+        }
+        bail!("shard not found in tablet {} for key: {:?}", self.id, key)
+    }
+
+    pub fn apply(&mut self, mut message: protos::DataMessage) -> Result<()> {
+        let cursor = MessageId::new(message.epoch, message.sequence);
+        self.update_cursor(cursor);
+        if let (Some(closed_timestamp), Some(leader_expiration)) =
+            (message.closed_timestamp.take(), message.leader_expiration.take())
+        {
+            let watermark = TabletWatermark { cursor, closed_timestamp, leader_expiration };
+            self.update_watermark(watermark);
+        }
+        let Some(temporal) = message.temporal.take() else {
+            return Ok(());
+        };
+        let temporal = Temporal::try_from(temporal)?;
+        let ts = temporal.timestamp();
+        let writes = Writes::from(message.operation.take());
+        for write in writes {
+            let shard = self.find_shard_mut(&write.key)?;
+            shard.store.put(write.key, ts, Value::from(write.value))?;
+        }
+        Ok(())
+    }
+
+    pub fn cursor(&self) -> MessageId {
+        self.watermark.cursor
+    }
+
+    pub fn watermark(&self) -> &TabletWatermark {
+        &self.watermark
+    }
+
+    pub fn update_watermark(&mut self, watermark: TabletWatermark) {
+        if watermark.cursor <= self.watermark.cursor {
+            if watermark.timing() > self.watermark.timing() {
+                self.watermark.closed_timestamp = watermark.closed_timestamp;
+                self.watermark.leader_expiration = watermark.leader_expiration;
+            }
+        } else if watermark.timing() > self.watermark.timing() {
+            self.watermarks.push_back(watermark);
+        }
+    }
+
+    pub fn get(&self, shard_id: ShardId, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue> {
+        let shard = self.get_shard(shard_id)?;
+        shard.get(temporal, key)
+    }
+
+    fn find(&self, shard_id: ShardId, key: &[u8], temporal: &Temporal) -> Result<(Vec<u8>, TimestampedValue)> {
+        let shard = self.get_shard(shard_id)?;
+        shard.find(temporal, key)
+    }
+
+    fn put(
+        &mut self,
+        shard_id: ShardId,
+        context: &mut BatchContext,
+        temporal: &Temporal,
+        key: &[u8],
+        value: Option<protos::Value>,
+        expect_ts: Option<Timestamp>,
+    ) -> Result<Timestamp> {
+        let shard = self.get_shard_mut(shard_id)?;
+        shard.put(context, temporal, key, value, expect_ts)
+    }
+
+    fn increment(
+        &mut self,
+        shard_id: ShardId,
+        context: &mut BatchContext,
+        temporal: &Temporal,
+        key: &[u8],
+        increment: i64,
+    ) -> Result<i64> {
+        let shard = self.get_shard_mut(shard_id)?;
+        shard.increment(context, temporal, key, increment)
+    }
+
+    /// FIXME: commit does not allow partial succeed.
+    fn commit(&mut self) -> Result<()> {
+        for shard in self.stores.iter_mut() {
+            shard.commit()?;
+        }
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        for shard in self.stores.iter_mut() {
+            shard.abort();
+        }
+    }
+
+    pub fn batch(
+        &mut self,
+        temporal: &mut Temporal,
+        shards: Vec<u64>,
+        requests: Vec<DataRequest>,
+    ) -> Result<BatchResult> {
+        self.cleanup();
+        let shards: Vec<ShardId> = unsafe { std::mem::transmute(shards) };
+        let mut context = BatchContext::default();
+        let mut blocker = ReplicationWatcher::default();
+        let mut responses = Vec::with_capacity(requests.len());
+        for (i, request) in requests.into_iter().enumerate() {
+            match request {
+                DataRequest::Get(get) => {
+                    let value = self.get(shards[i], temporal, &get.key)?;
+                    blocker.watch(&value.value);
+                    let response = GetResponse { value: value.into() };
+                    responses.push(DataResponse::Get(response));
+                },
+                DataRequest::Find(find) => {
+                    let (key, value) = self.find(shards[i], &find.key, temporal)?;
+                    blocker.watch(&value.value);
+                    let response = FindResponse { key, value: value.into() };
+                    responses.push(DataResponse::Find(response));
+                },
+                DataRequest::Put(put) => {
+                    let ts = self.put(shards[i], &mut context, temporal, &put.key, put.value, put.expect_ts)?;
+                    let response = PutResponse { write_ts: ts };
+                    responses.push(DataResponse::Put(response));
+                },
+                DataRequest::Increment(increment) => {
+                    let incremented =
+                        self.increment(shards[i], &mut context, temporal, &increment.key, increment.increment)?;
+                    let response = IncrementResponse { value: incremented };
+                    responses.push(DataResponse::Increment(response));
+                },
+            }
+        }
+        if !context.writes.is_empty() {
+            self.step();
+            self.commit()?;
+        }
+        Ok(BatchResult {
+            ts: temporal.timestamp(),
+            blocker,
+            responses,
+            writes: context.writes,
+            replication: context.replication,
+        })
+    }
+}
+
+pub trait DataStore: Send + Sync {
+    fn get(&self, temporal: &Temporal, key: &[u8]) -> Result<TimestampedValue>;
+
+    fn put(&mut self, key: Vec<u8>, ts: Timestamp, value: Value) -> Result<()>;
+
+    fn find(&self, key: &[u8], temporal: &Temporal) -> Result<(Vec<u8>, TimestampedValue)>;
+}


### PR DESCRIPTION
Previously, tablets are bound to ranges and their deployments. Though,
ranges are not necessary to be small enough for migration in SeamDB as
shared-nothing databases, but it is still a good to colocate them for
better transaction batch and read locality.

This pr make a few concept changes:
* A shard is a store unit to store continuous data in one range.
* A tablet is a deployment unit to serve multiple shards.
* Descriptors and deployments of tablets are stored separately per-shard
  in root tablet. We probably will store them in leveled shards just
  like how we store range descriptors.

Resolves #13.
